### PR TITLE
Added Support for JPA Entities export.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /target
 /.classpath
 /.project
+.~users.xlsx
+users.xlsx

--- a/README.md
+++ b/README.md
@@ -238,3 +238,22 @@ Add xcelite as a dependency:
 			<version>1.0.4</version>
 </dependency>
 ```
+### OR
+Add this repository as dependency, if you want support for Jpa data export. 
+```xml
+<repositories>
+	<repository>
+		<id>Github</id>
+		<name>Github repository</name>
+		<url>https://raw.github.com/boriswaguia/xcelite/release</url>
+	</repository>
+</repositories>
+```
+
+```xml
+<dependency>
+	<groupId>com.ebay</groupId>
+	<artifactId>xcelite</artifactId>
+	<version>1.0.5-SNAPSHOT</version>
+</dependency>
+```

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.ebay</groupId>
 	<artifactId>xcelite</artifactId>
-	<version>1.0.7-SNAPSHOT</version>
+	<version>1.0.8-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>xcelite</name>
 	<description>Xcelite is an ORM like Java library which allows you to easily serialize and deserialize Java beans to/from Excel spreadsheets</description>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.ebay</groupId>
 	<artifactId>xcelite</artifactId>
-	<version>1.0.5-SNAPSHOT</version>
+	<version>1.0.6-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>xcelite</name>
 	<description>Xcelite is an ORM like Java library which allows you to easily serialize and deserialize Java beans to/from Excel spreadsheets</description>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>2.9.1</version>
+				<configuration>
+					<additionalparam>-Xdoclint:none</additionalparam>
+				</configuration>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
@@ -119,6 +122,19 @@
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
 			<version>3.2.1</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.hibernate.javax.persistence/hibernate-jpa-2.0-api -->
+		<dependency>
+		    <groupId>org.hibernate.javax.persistence</groupId>
+		    <artifactId>hibernate-jpa-2.0-api</artifactId>
+		    <version>1.0.1.Final</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/junit/junit -->
+		<dependency>
+		    <groupId>junit</groupId>
+		    <artifactId>junit</artifactId>
+		    <version>4.12</version>
+		    <scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.ebay</groupId>
 	<artifactId>xcelite</artifactId>
-	<version>1.0.6-SNAPSHOT</version>
+	<version>1.0.7-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>xcelite</name>
 	<description>Xcelite is an ORM like Java library which allows you to easily serialize and deserialize Java beans to/from Excel spreadsheets</description>

--- a/src/main/java/com/ebay/xcelite/column/Col.java
+++ b/src/main/java/com/ebay/xcelite/column/Col.java
@@ -38,10 +38,16 @@ public class Col implements Comparable<Col> {
   }
 
   public Col(String name, String fieldName) {
+	  this(name, fieldName, String.class);
+  }
+  
+
+  public Col(String name, String fieldName, Class<?> type) {
     this.name = name;
     this.fieldName = fieldName;
-    type = String.class;
+    this.type = type;
   }
+  
 
   @Override
   public String toString() {

--- a/src/main/java/com/ebay/xcelite/column/ColumnsExtractor.java
+++ b/src/main/java/com/ebay/xcelite/column/ColumnsExtractor.java
@@ -17,10 +17,14 @@ package com.ebay.xcelite.column;
 
 import static org.reflections.ReflectionUtils.withAnnotation;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
 import org.reflections.ReflectionUtils;
 
@@ -79,7 +83,7 @@ public class ColumnsExtractor {
         col.setConverter(annotation.converter());
       }
       columns.add(col);
-    }   
+    }
     
     if (colsOrdering != null) {
       orderColumns();
@@ -87,6 +91,48 @@ public class ColumnsExtractor {
     
     extractAnyColumn();
   }
+  
+
+  @SuppressWarnings("unchecked")
+  public void extractJpa() {    
+    Set<Field> idFields = ReflectionUtils.getAllFields(type, withAnnotation(javax.persistence.Id.class));
+    Set<Field> columnFields = ReflectionUtils.getAllFields(type, withAnnotation(javax.persistence.Column.class));
+    Set<Field> manyToOneFields = ReflectionUtils.getAllFields(type, withAnnotation(ManyToOne.class));
+
+    for (Field columnField : idFields) {
+      javax.persistence.Id annotation = columnField.getAnnotation(javax.persistence.Id.class);
+      if(annotation == null) continue;
+      Col col = null;
+      col = new Col(columnField.getName(), columnField.getName());
+      columns.add(col);
+    }
+    
+    for (Field columnField : columnFields) {
+      javax.persistence.Column annotation = columnField.getAnnotation(javax.persistence.Column.class);
+      if(annotation == null) continue;
+      Col col = null;
+      if (annotation.name().isEmpty()) {
+        col = new Col(columnField.getName(), columnField.getName());        
+      } else {
+        col = new Col(annotation.name(), columnField.getName());        
+      }
+      columns.add(col);
+    }
+
+    for (Field columnField : manyToOneFields) {
+      ManyToOne annotation = columnField.getAnnotation(ManyToOne.class);
+      Col col = null;
+      if(annotation == null) continue;
+      JoinColumn joinColumn = columnField.getAnnotation(JoinColumn.class);
+      if (joinColumn.name().isEmpty()) {
+        col = new Col(columnField.getName(), columnField.getName(), columnField.getType());        
+      } else {
+        col = new Col(joinColumn.name(), columnField.getName(), columnField.getType());
+      }
+      columns.add(col);
+    }
+  }
+  
   
   @SuppressWarnings("unchecked")
   private void extractAnyColumn() {

--- a/src/main/java/com/ebay/xcelite/column/ColumnsExtractor.java
+++ b/src/main/java/com/ebay/xcelite/column/ColumnsExtractor.java
@@ -17,7 +17,6 @@ package com.ebay.xcelite.column;
 
 import static org.reflections.ReflectionUtils.withAnnotation;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -97,13 +96,13 @@ public class ColumnsExtractor {
   public void extractJpa() {    
     Set<Field> idFields = ReflectionUtils.getAllFields(type, withAnnotation(javax.persistence.Id.class));
     Set<Field> columnFields = ReflectionUtils.getAllFields(type, withAnnotation(javax.persistence.Column.class));
-    Set<Field> manyToOneFields = ReflectionUtils.getAllFields(type, withAnnotation(ManyToOne.class));
+    Set<Field> manyToOneFields = ReflectionUtils.getAllFields(type, withAnnotation(javax.persistence.ManyToOne.class));
 
     for (Field columnField : idFields) {
       javax.persistence.Id annotation = columnField.getAnnotation(javax.persistence.Id.class);
       if(annotation == null) continue;
       Col col = null;
-      col = new Col(columnField.getName(), columnField.getName());
+      col = new Col(columnField.getName(), columnField.getName(), columnField.getType());
       columns.add(col);
     }
     
@@ -112,18 +111,18 @@ public class ColumnsExtractor {
       if(annotation == null) continue;
       Col col = null;
       if (annotation.name().isEmpty()) {
-        col = new Col(columnField.getName(), columnField.getName());        
+        col = new Col(columnField.getName(), columnField.getName(),  columnField.getType());        
       } else {
-        col = new Col(annotation.name(), columnField.getName());        
+        col = new Col(annotation.name(), columnField.getName(), columnField.getType());
       }
       columns.add(col);
     }
 
     for (Field columnField : manyToOneFields) {
-      ManyToOne annotation = columnField.getAnnotation(ManyToOne.class);
+      ManyToOne annotation = columnField.getAnnotation(javax.persistence.ManyToOne.class);
       Col col = null;
       if(annotation == null) continue;
-      JoinColumn joinColumn = columnField.getAnnotation(JoinColumn.class);
+      JoinColumn joinColumn = columnField.getAnnotation(javax.persistence.JoinColumn.class);
       if (joinColumn.name().isEmpty()) {
         col = new Col(columnField.getName(), columnField.getName(), columnField.getType());        
       } else {
@@ -154,7 +153,7 @@ public class ColumnsExtractor {
       if (annotation.converter() != NoConverterClass.class) {
         anyColumn.setConverter(annotation.converter());
       }
-    }    
+    }
   }
 
   private void orderColumns() {

--- a/src/main/java/com/ebay/xcelite/reader/BeanSheetReader.java
+++ b/src/main/java/com/ebay/xcelite/reader/BeanSheetReader.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.poi.ss.format.CellFormatType;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.DateUtil;
 import org.apache.poi.ss.usermodel.Row;
@@ -165,7 +166,10 @@ public class BeanSheetReader<T> extends SheetReaderAbs<T> {
   @SuppressWarnings("unchecked")
   private void writeToField(Field field, T object, Cell cell, Col column) {
     try {   
-      Object cellValue = readValueFromCell(cell);      
+      Object cellValue = readValueFromCell(cell);
+      if(cellValue == null && (field.getType() == Boolean.class || field.getType() == boolean.class)) {
+    	  cellValue = Boolean.FALSE;
+      }
       if (cellValue != null) {
         if (column.getConverter() != null) {
           ColumnValueConverter<Object, ?> converter = (ColumnValueConverter<Object, ?>) column.getConverter()
@@ -227,6 +231,9 @@ public class BeanSheetReader<T> extends SheetReaderAbs<T> {
     }
     if (fieldType == Date.class) {
       return DateUtil.getJavaDate(Double.valueOf(value));
+    }
+    if(fieldType == Boolean.class || fieldType == boolean.class) {
+    	return Boolean.valueOf(value);
     }
     return value;
   }

--- a/src/main/java/com/ebay/xcelite/styles/CellStyles.java
+++ b/src/main/java/com/ebay/xcelite/styles/CellStyles.java
@@ -22,7 +22,8 @@ import org.apache.poi.ss.usermodel.Workbook;
 
 public final class CellStyles {
   
-  private final String DEFAULT_DATE_FORMAT = "ddd mmm dd hh:mm:ss yyy";
+//  private final String DEFAULT_DATE_FORMAT = "ddd mmm dd hh:mm:ss yyy";
+  private final String DEFAULT_DATE_FORMAT = "dd/mm/yyyy hh:mm:ss";
   
   private final Workbook wb;
   private CellStyle boldStyle;

--- a/src/main/java/com/ebay/xcelite/writer/BeanSheetWriter.java
+++ b/src/main/java/com/ebay/xcelite/writer/BeanSheetWriter.java
@@ -46,6 +46,7 @@ public class BeanSheetWriter<T> extends SheetWriterAbs<T> {
     super(sheet, true);
     ColumnsExtractor extractor = new ColumnsExtractor(type);
     extractor.extract();
+    extractor.extractJpa();
     columns = extractor.getColumns();
     anyColumn = extractor.getAnyColumn();
   }

--- a/src/main/java/com/ebay/xcelite/writer/BeanSheetWriter.java
+++ b/src/main/java/com/ebay/xcelite/writer/BeanSheetWriter.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
 import org.reflections.ReflectionUtils;
 
 import com.ebay.xcelite.annotate.NoConverterClass;
@@ -120,8 +121,9 @@ public class BeanSheetWriter<T> extends SheetWriterAbs<T> {
     }
 
     if (col.getType() == Date.class) {
-      if (col.getDataFormat() == null) {
-        cell.setCellStyle(CellStylesBank.get(sheet.getNativeSheet().getWorkbook()).getDateStyle());
+     if (col.getDataFormat() == null) {
+        CellStyle dateStyle = CellStylesBank.get(sheet.getNativeSheet().getWorkbook()).getDateStyle();
+		cell.setCellStyle(dateStyle);
       }
     }
 


### PR DESCRIPTION
Hi,

**Context**
Xcelite is a great java library. As Java developers, we are frequently working with JPA entities.
Then come the need to export jpa data to an excel file.

So instead of having  to create more POJO, or having to decorate my JPA entities with more Annotations, I thought we might be better off adding support for jpa annotations to the library.

**Features added**
This PR currently has the following implementations :

- Jpa properties annotated with javax.annotation.Column are going to be exported.

- Jpa properties annoted with @ManyToOne are going to be exported. Note : If a property is annotated with @JoinColumn and the name of the join is provided, that name will be used as the name of the column in the excel file.

Although there are lot of things to be improved, let me have your feelings about this.

Thanks for reading
Boris 